### PR TITLE
ExchangeRateProvider implementation

### DIFF
--- a/Backend/Task/ExchangeRateProvider.cs
+++ b/Backend/Task/ExchangeRateProvider.cs
@@ -1,10 +1,38 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Net;
+using System.Text;
+using System.Xml.Serialization;
 
 namespace ExchangeRateUpdater
 {
     public class ExchangeRateProvider
     {
+
+        private const string XmlApi =
+            @"https://www.cnb.cz/cs/financni_trhy/devizovy_trh/kurzy_devizoveho_trhu/denni_kurz.xml";
+
+        private const int NewRatesPublishHour = 14;
+        private RateTable Cache { get; set; }
+        private DateTime RefreshCache { get; set; } = DateTime.MinValue;
+
+        private RateTable DownloadTable()
+        {
+            var now = DateTime.Now;
+            if (Cache != null && (now.Date < RefreshCache.Date || now >= RefreshCache.Date && now.Hour < NewRatesPublishHour)) return Cache;
+
+            using (var client = new WebClient())
+            using (var dataStream = new MemoryStream(client.DownloadData(XmlApi)))
+            {
+                var xmlSerializer = new XmlSerializer(typeof(RateTable));
+                Cache = (RateTable)xmlSerializer.Deserialize(dataStream);
+                RefreshCache = DateTime.ParseExact(Cache.Date, "dd.MM.yyyy", null).AddDays(1);
+                return Cache;
+            }
+        }
+
         /// <summary>
         /// Should return exchange rates among the specified currencies that are defined by the source. But only those defined
         /// by the source, do not return calculated exchange rates. E.g. if the source contains "EUR/USD" but not "USD/EUR",
@@ -13,7 +41,15 @@ namespace ExchangeRateUpdater
         /// </summary>
         public IEnumerable<ExchangeRate> GetExchangeRates(IEnumerable<Currency> currencies)
         {
-            return Enumerable.Empty<ExchangeRate>();
+            var rates = DownloadTable().Rates.ToDictionary(x => x.Code);
+            var target = new Currency("CZK");//fetching table from CNB
+
+            foreach (var currency in currencies)
+            {
+                if (!rates.ContainsKey(currency.Code)) continue;
+                var rate = rates[currency.Code];
+                yield return new ExchangeRate(currency, target, rate.ExchangeRate / rate.Amount);
+            }
         }
     }
 }

--- a/Backend/Task/ExchangeRateUpdater.csproj
+++ b/Backend/Task/ExchangeRateUpdater.csproj
@@ -47,6 +47,8 @@
     <Compile Include="ExchangeRate.cs" />
     <Compile Include="ExchangeRateProvider.cs" />
     <Compile Include="Program.cs" />
+    <Compile Include="Rate.cs" />
+    <Compile Include="RateTable.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/Backend/Task/Rate.cs
+++ b/Backend/Task/Rate.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Xml.Serialization;
+
+namespace ExchangeRateUpdater
+{
+    [Serializable]
+    public class Rate
+    {
+        [XmlAttribute("kod")]
+        public string Code { get; set; }
+        [XmlAttribute("mena")]
+        public string CurrencyName { get; set; }
+        [XmlAttribute("mnozstvi")]
+        public int Amount { get; set; }
+        [XmlIgnore]
+        public decimal ExchangeRate { get; set; }
+        [XmlAttribute("poradi")]
+        public string CountryName { get; set; }
+
+        /// <summary>
+        /// Used for deserialization. Be ware of culture info, when it's used for serialize.
+        /// </summary>
+        [XmlAttribute("kurz")]
+        public string ExchangeRateSerialize
+        {
+            get => $"{ExchangeRate}";
+            set => ExchangeRate = decimal.Parse(value.Replace(',', '.'));
+        }
+
+    }
+}

--- a/Backend/Task/RateTable.cs
+++ b/Backend/Task/RateTable.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Xml.Serialization;
+
+namespace ExchangeRateUpdater
+{
+    [Serializable]
+    [XmlRoot(@"kurzy")]
+    public class RateTable
+    {
+        [XmlAttribute("banka")]
+        public string Bank { get; set; }
+
+        [XmlAttribute("datum")]
+        public string Date { get; set; }
+
+        [XmlAttribute("poradi")]
+        public int RateOrder { get; set; }
+
+        [XmlArray("tabulka"), XmlArrayItem("radek")]
+        public List<Rate> Rates { get; set; }
+    }
+}


### PR DESCRIPTION
`ExchangeRateProvider` implemented for target currency CZK when the source should CNB. 
The Czech version of API is used and it's tested with US Windows localization. 

Implemented caching, because of test application is using the result of the provider twice. 