### PR TITLE
Victors code task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,3 @@
 node_modules
 bower_components
 npm-debug.log
-/Backend/Task/.vs/ExchangeRateUpdater/v16/Server/sqlite3
-/Backend/Task/packages
-/Backend/Task/ExchangeRateUdapterTests

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@
 node_modules
 bower_components
 npm-debug.log
+/Backend/Task/.vs/ExchangeRateUpdater/v16/Server/sqlite3
+/Backend/Task/packages
+/Backend/Task/ExchangeRateUdapterTests

--- a/Backend/Task/CnbProvider/CnbExchangeRatesProvider.cs
+++ b/Backend/Task/CnbProvider/CnbExchangeRatesProvider.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace ExchangeRateUpdater.CnbProvider
+{
+    /// <summary>
+    /// Provides FX rates for CZK from Czech National Bank site www.cnb.cz
+    /// </summary>
+    class CnbExchangeRatesProvider : ICustomExchangeRatesProvider
+    {
+        public static readonly Currency ProviderCurrency = new Currency("CZK");
+
+        private readonly ICnbFxRatesWebLoader _cnbFxRatesWebLoader;
+
+        private readonly List<CnbFxRatesSource> _cnbRatesSources = new List<CnbFxRatesSource>
+        {
+            new CnbFxMainCurrenciesSource(),
+            new CnbFxOtherCurrenciesSource()
+        };
+
+        public CnbExchangeRatesProvider(ICnbFxRatesWebLoader cnbFxRatesWebLoader)
+        {
+            _cnbFxRatesWebLoader = cnbFxRatesWebLoader ?? throw new ArgumentNullException(nameof(cnbFxRatesWebLoader));
+        }
+
+        CnbExchangeRatesProvider(ICnbFxRatesWebLoader cnbFxRatesWebLoader, List<CnbFxRatesSource> cnbRatesSources)
+        {
+            _cnbRatesSources = cnbRatesSources ?? throw new ArgumentNullException(nameof(cnbRatesSources));
+            _cnbFxRatesWebLoader = cnbFxRatesWebLoader ?? throw new ArgumentNullException(nameof(cnbFxRatesWebLoader));
+        }
+
+        public async Task<(IEnumerable<ExchangeRate> rates, bool ratesWhereUpdated)> GetAllRatesAsync()
+        {
+            bool ratesWhereUpdated = false;
+
+            var syncSources = _cnbRatesSources.Where(x => x.NewRatesAvailable()).Select(_cnbFxRatesWebLoader.TryGetLatestRates).ToList();
+            if (syncSources.Any())
+            {
+                var result = await Task.WhenAll(syncSources).ConfigureAwait(false);
+                ratesWhereUpdated = result.Any(updated => updated);
+            }
+            
+            return (_cnbRatesSources.SelectMany(rateSource => rateSource.Current.LoadedRates), ratesWhereUpdated);
+        }
+    }
+}

--- a/Backend/Task/CnbProvider/CnbFxMainCurrenciesSource.cs
+++ b/Backend/Task/CnbProvider/CnbFxMainCurrenciesSource.cs
@@ -1,0 +1,43 @@
+﻿using System;
+
+namespace ExchangeRateUpdater.CnbProvider
+{
+    /// <summary>
+    /// Main currencies with planned update time daily as per https://www.cnb.cz/en/faq/Format-of-the-foreign-exchange-market-rates
+    /// </summary>
+    class CnbFxMainCurrenciesSource : CnbFxRatesSource
+    {
+        private static readonly (int hour, int minutes) PlannedFxRateUpdateTime = (hour: 14, minutes: 30);
+
+        private readonly Func<DateTime> _dateTimeNowFunc;
+
+        public CnbFxMainCurrenciesSource() : this(() => DateTime.Now)
+        { }
+
+        internal CnbFxMainCurrenciesSource(Func<DateTime> dateTimeNowFunc)
+        {
+            _dateTimeNowFunc = dateTimeNowFunc ?? throw new ArgumentNullException(nameof(dateTimeNowFunc));
+        }
+
+        public override string Url => "https://www.cnb.cz/en/financial-markets/foreign-exchange-market/central-bank-exchange-rate-fixing/central-bank-exchange-rate-fixing/daily.txt";
+
+        public override string CreateQueryString()
+        {
+            return $"date={GetLastExpectedUpdateDateTimeForFxRate(PlannedFxRateUpdateTime):dd.MM.yyyy}";
+        }
+
+        internal DateTime GetLastExpectedUpdateDateTimeForFxRate((int hour, int minutes) plannedRateUpdateTime)
+        {
+            var dtNow = _dateTimeNowFunc();
+            DateTime scheduledUpdateTime = new DateTime(dtNow.Year, dtNow.Month, dtNow.Day, plannedRateUpdateTime.hour, plannedRateUpdateTime.minutes, 0);
+
+            //if update was not published yet we need to get one from prev work day
+            if (scheduledUpdateTime > dtNow)
+                scheduledUpdateTime = scheduledUpdateTime.AddDays(-1);
+
+            scheduledUpdateTime = base.AdjustDateToLastWorkingDay(scheduledUpdateTime);
+
+            return scheduledUpdateTime;
+        }
+    }
+}

--- a/Backend/Task/CnbProvider/CnbFxOtherCurrenciesSource.cs
+++ b/Backend/Task/CnbProvider/CnbFxOtherCurrenciesSource.cs
@@ -1,0 +1,41 @@
+﻿using System;
+
+namespace ExchangeRateUpdater.CnbProvider
+{
+    /// <summary>
+    ///  The rates of other currencies are set every last working day in a month.
+    ///  https://www.cnb.cz/en/financial-markets/foreign-exchange-market/methodology-rates-of-other-currencies/
+    /// </summary>
+    class CnbFxOtherCurrenciesSource : CnbFxRatesSource
+    {
+        //Time is not clear, lets assume its same as for main currencies
+        private static readonly (int hour, int minutes) PlannedFxRateUpdateTime = (hour: 14, minutes: 30);
+
+        private readonly Func<DateTime> _dateTimeNowFunc;
+
+        public CnbFxOtherCurrenciesSource() : this(() => DateTime.Now) 
+        { }
+
+        internal CnbFxOtherCurrenciesSource(Func<DateTime> dateTimeNowFunc)
+        {
+            _dateTimeNowFunc = dateTimeNowFunc ?? throw new ArgumentNullException(nameof(dateTimeNowFunc));
+        }
+
+        public override string Url => "https://www.cnb.cz/en/financial-markets/foreign-exchange-market/fx-rates-of-other-currencies/fx-rates-of-other-currencies/fx_rates.txt";
+
+     
+        public override string CreateQueryString()
+        {
+            var dtNow = _dateTimeNowFunc();
+            var lastDayOfTheMonth = new DateTime(dtNow.Year, dtNow.Month, DateTime.DaysInMonth(dtNow.Year, dtNow.Month), PlannedFxRateUpdateTime.hour, PlannedFxRateUpdateTime.minutes, 0);
+
+            var scheduledDateTimeAtTheEndOfTheMonth = base.AdjustDateToLastWorkingDay(lastDayOfTheMonth);
+
+            //if new rates where not published yet this month, we need to get previous ones. No need for precises day 
+            if (scheduledDateTimeAtTheEndOfTheMonth > dtNow) 
+                scheduledDateTimeAtTheEndOfTheMonth = scheduledDateTimeAtTheEndOfTheMonth.AddMonths(-1);
+            
+            return $"year={scheduledDateTimeAtTheEndOfTheMonth.Year}&month={scheduledDateTimeAtTheEndOfTheMonth.Month}";
+        }
+    }
+}

--- a/Backend/Task/CnbProvider/CnbFxRateRowParser.cs
+++ b/Backend/Task/CnbProvider/CnbFxRateRowParser.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Globalization;
+
+namespace ExchangeRateUpdater.CnbProvider
+{
+    interface ICnbFxRateRowParser
+    {
+        ExchangeRate ParseRateRow(string rateAsString);
+    }
+
+    class CnbFxRateRowParser : ICnbFxRateRowParser
+    {
+        private const char Separator = '|';
+
+        private static class ColumnIndex
+        {
+            public const int Country = 0;
+            public const int Name = 1;
+            public const int Amount = 2;
+            public const int Code = 3;
+            public const int Value = 4;
+        }
+
+        public ExchangeRate ParseRateRow(string rateAsString)
+        {
+            if (string.IsNullOrWhiteSpace(rateAsString)) return null; 
+
+            try
+            {
+                var rateStringSplit = rateAsString.Split(Separator);
+                var cnbRate = new CnbRate(rateStringSplit[ColumnIndex.Code], rateStringSplit[ColumnIndex.Value], rateStringSplit[ColumnIndex.Amount]);
+
+                return new ExchangeRate(
+                    sourceCurrency: CnbExchangeRatesProvider.ProviderCurrency, 
+                    targetCurrency: new Currency(cnbRate.Code),
+                             value: cnbRate.Value / cnbRate.Amount);
+            }
+            catch (Exception e)
+            {
+                //log rateAsString, e
+                return null;
+            }
+        }
+
+        private struct CnbRate
+        {
+            public CnbRate(string code, string value, string amount)
+            {
+                Code = code;
+                Amount = int.Parse(amount);
+                Value = decimal.Parse(value, NumberStyles.AllowDecimalPoint);
+            }
+
+            public string Code { get; }
+
+            public decimal Value { get; }
+
+            public int Amount { get; }
+        }
+    }
+}

--- a/Backend/Task/CnbProvider/CnbFxRatesSource.cs
+++ b/Backend/Task/CnbProvider/CnbFxRatesSource.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace ExchangeRateUpdater.CnbProvider
+{
+    abstract class CnbFxRatesSource
+    {
+        protected CnbFxRatesSource()
+        {
+            Current = new Context(new List<ExchangeRate>(), string.Empty, string.Empty);
+        }
+
+        public Context Current { get; set; }
+
+        /// <summary>
+        /// Endpoint url
+        /// </summary>
+        public abstract string Url { get; }
+
+        /// <summary>
+        /// Generate a query string for given API
+        /// </summary>
+        public abstract string CreateQueryString();
+
+        /// <summary>
+        /// True if we expect that new rates where published for that source
+        /// </summary>
+        public virtual bool NewRatesAvailable()
+        {
+           return Current.LastUsedQueryString == string.Empty || Current.LastUsedQueryString != CreateQueryString();
+        }
+
+        /// <summary>
+        /// Has document changed since last update
+        /// </summary>
+        public virtual bool VersionsMatch(string topDocumentRow)
+        {
+            return topDocumentRow == Current.VersionRowFromPrevUpdate;
+        }
+
+        public class Context
+        {
+            public Context(IEnumerable<ExchangeRate> newRates, string usedQueryString, string versionRow)
+            {
+                LoadedRates = newRates;
+                LastUsedQueryString = usedQueryString;
+                VersionRowFromPrevUpdate = versionRow;
+            }
+
+            public IEnumerable<ExchangeRate> LoadedRates { get; }
+            public string LastUsedQueryString { get; }
+            public string VersionRowFromPrevUpdate { get; }
+        }
+
+        protected DateTime AdjustDateToLastWorkingDay(DateTime fromDateTime)
+        {
+            switch (fromDateTime.DayOfWeek)
+            {
+                case DayOfWeek.Sunday:
+                    return fromDateTime.AddDays(-2);
+                case DayOfWeek.Saturday:
+                    return fromDateTime.AddDays(-1);
+                default:
+                    //Bug: There will be no update published on public holidays.
+                    //Please, don't run this code on prod during czech public holidays.
+                    return fromDateTime;
+            }
+        }
+    }
+}

--- a/Backend/Task/CnbProvider/CnbFxRatesWebLoader.cs
+++ b/Backend/Task/CnbProvider/CnbFxRatesWebLoader.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Polly;
+
+namespace ExchangeRateUpdater.CnbProvider
+{
+    internal interface ICnbFxRatesWebLoader
+    {
+        /// <summary>
+        /// Will try to get rates from source if newer version was published
+        /// </summary>
+        /// <returns>Rates where updated</returns>
+        Task<bool> TryGetLatestRates(CnbFxRatesSource source);
+    }
+
+    class CnbFxRatesWebLoader : ICnbFxRatesWebLoader
+    {
+        private static readonly (int retries, TimeSpan waitTime, TimeSpan timeout) PolicyConfig = (retries: 3, waitTime: TimeSpan.FromSeconds(10), timeout: TimeSpan.FromMinutes(1));
+        private static readonly HttpClient HttpClient =  new HttpClient { Timeout = PolicyConfig.timeout };
+    
+        private readonly ICnbFxRateRowParser _cnbRateParser;
+
+        public CnbFxRatesWebLoader(ICnbFxRateRowParser cnbFxRateRowParser)
+        {
+            _cnbRateParser = cnbFxRateRowParser ?? throw new ArgumentNullException(nameof(cnbFxRateRowParser));
+        }
+
+        public async Task<bool> TryGetLatestRates(CnbFxRatesSource source)
+        {
+            var query = source.CreateQueryString();
+
+            //external web source, we need to handle outages
+            var policy = Policy.Handle<HttpRequestException>().WaitAndRetryAsync(PolicyConfig.retries, wait => PolicyConfig.waitTime);
+
+            using (var streamReader = new StreamReader(await policy.ExecuteAsync(()=> HttpClient.GetStreamAsync($"{source.Url}?{query}")).ConfigureAwait(false)))
+            {
+                if (streamReader.EndOfStream)
+                    return false;
+
+                var versionRow = await streamReader.ReadLineAsync();
+
+                if (source.VersionsMatch(versionRow))
+                    return false;
+
+                await SkipHeader(streamReader);
+
+                source.Current = new CnbFxRatesSource.Context(newRates: await ParseAllRates(streamReader), usedQueryString: query, versionRow: versionRow);
+            }
+
+            return true;
+        }
+
+        private static async Task SkipHeader(StreamReader streamReader)
+        {
+            if (!streamReader.EndOfStream) await streamReader.ReadLineAsync();
+        }
+
+        private async Task<List<ExchangeRate>> ParseAllRates(StreamReader streamReader)
+        {
+            var result = new List<ExchangeRate>();
+            while (!streamReader.EndOfStream)
+            {
+                var rate = _cnbRateParser.ParseRateRow(await streamReader.ReadLineAsync());
+                if (rate != null) result.Add(rate);
+            }
+
+            return result;
+        }
+    }
+}

--- a/Backend/Task/Currency.cs
+++ b/Backend/Task/Currency.cs
@@ -1,6 +1,8 @@
-﻿namespace ExchangeRateUpdater
+﻿using System;
+
+namespace ExchangeRateUpdater
 {
-    public class Currency
+    public class Currency: IEquatable<Currency>
     {
         public Currency(string code)
         {
@@ -15,6 +17,36 @@
         public override string ToString()
         {
             return Code;
+        }
+
+        public bool Equals(Currency other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return Code == other.Code;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((Currency) obj);
+        }
+
+        public static bool operator ==(Currency x, Currency y)
+        {
+            return !(x is null) && x.Equals(y);
+        }
+
+        public static bool operator !=(Currency x, Currency y)
+        {
+            return !(x == y);
+        }
+
+        public override int GetHashCode()
+        {
+            return (Code != null ? Code.GetHashCode() : 0);
         }
     }
 }

--- a/Backend/Task/ExchangeRateProvider.cs
+++ b/Backend/Task/ExchangeRateProvider.cs
@@ -1,10 +1,27 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
+using ExchangeRateUpdater.CnbProvider;
 
 namespace ExchangeRateUpdater
 {
     public class ExchangeRateProvider
     {
+        private IReadOnlyDictionary<Currency, ExchangeRate> _rates = new Dictionary<Currency, ExchangeRate>();
+
+        private readonly ICustomExchangeRatesProvider _provider;
+
+        public ExchangeRateProvider(ICustomExchangeRatesProvider provider)
+        {
+            _provider = provider ?? throw new ArgumentNullException(nameof(provider));
+        }
+
+        public ExchangeRateProvider():this(new CnbExchangeRatesProvider(new CnbFxRatesWebLoader(new CnbFxRateRowParser())))
+        {
+            //Actual provider should be injected of course but adding container here would be an overkill
+        }
+
         /// <summary>
         /// Should return exchange rates among the specified currencies that are defined by the source. But only those defined
         /// by the source, do not return calculated exchange rates. E.g. if the source contains "EUR/USD" but not "USD/EUR",
@@ -13,7 +30,22 @@ namespace ExchangeRateUpdater
         /// </summary>
         public IEnumerable<ExchangeRate> GetExchangeRates(IEnumerable<Currency> currencies)
         {
-            return Enumerable.Empty<ExchangeRate>();
+            SyncRates();
+            foreach (var currency in currencies)
+            {
+                if (_rates.TryGetValue(currency, out var returnValue))
+                   yield return returnValue;
+            }
+        }
+
+        private void SyncRates()
+        {
+            var result = Task.Run(_provider.GetAllRatesAsync).ConfigureAwait(false).GetAwaiter().GetResult();
+
+            if (result.ratesWhereUpdated && result.rates != null)
+            {
+                _rates = result.rates.ToDictionary(x => x.TargetCurrency, x => x);
+            }
         }
     }
 }

--- a/Backend/Task/ExchangeRateUpdater.csproj
+++ b/Backend/Task/ExchangeRateUpdater.csproj
@@ -9,9 +9,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ExchangeRateUpdater</RootNamespace>
     <AssemblyName>ExchangeRateUpdater</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -33,6 +34,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Polly, Version=7.0.0.0, Culture=neutral, PublicKeyToken=c8a3ffc3f8f825cc, processorArchitecture=MSIL">
+      <HintPath>packages\Polly.7.1.0\lib\netstandard2.0\Polly.dll</HintPath>
+    </Reference>
+    <Reference Include="Polly.Extensions.Http, Version=3.0.0.0, Culture=neutral, PublicKeyToken=c8a3ffc3f8f825cc, processorArchitecture=MSIL">
+      <HintPath>packages\Polly.Extensions.Http.3.0.0\lib\netstandard2.0\Polly.Extensions.Http.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -43,13 +50,23 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CnbProvider\CnbExchangeRatesProvider.cs" />
+    <Compile Include="CnbProvider\CnbFxRateRowParser.cs" />
+    <Compile Include="CnbProvider\CnbFxMainCurrenciesSource.cs" />
+    <Compile Include="CnbProvider\CnbFxOtherCurrenciesSource.cs" />
+    <Compile Include="CnbProvider\CnbFxRatesSource.cs" />
+    <Compile Include="CnbProvider\CnbFxRatesWebLoader.cs" />
     <Compile Include="Currency.cs" />
     <Compile Include="ExchangeRate.cs" />
     <Compile Include="ExchangeRateProvider.cs" />
+    <Compile Include="ICustomExchangeRatesProvider.cs" />
     <Compile Include="Program.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Backend/Task/ExchangeRateUpdater.sln
+++ b/Backend/Task/ExchangeRateUpdater.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29403.142
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExchangeRateUpdater", "ExchangeRateUpdater.csproj", "{7B2695D6-D24C-4460-A58E-A10F08550CE0}"
 EndProject
@@ -18,5 +18,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {9FAA6665-28C7-4D18-A96F-2225B60E23BF}
 	EndGlobalSection
 EndGlobal

--- a/Backend/Task/ICustomExchangeRatesProvider.cs
+++ b/Backend/Task/ICustomExchangeRatesProvider.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace ExchangeRateUpdater
+{
+    public interface ICustomExchangeRatesProvider
+    {
+        /// <summary>
+        /// Provides fx rates from specific source
+        /// </summary>
+        /// <returns>
+        /// rates - all loaded rates
+        /// ratesWhereUpdated - new rates where loaded from the source
+        /// </returns>
+        Task<(IEnumerable<ExchangeRate> rates, bool ratesWhereUpdated)> GetAllRatesAsync(); 
+    }
+}

--- a/Backend/Task/packages.config
+++ b/Backend/Task/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Polly" version="7.1.0" targetFramework="net48" />
+  <package id="Polly.Extensions.Http" version="3.0.0" targetFramework="net48" />
+</packages>


### PR DESCRIPTION
I tried to make task a bit more interesting then just parsing text from couple of sources: What if we need to query rates again? 
The most costly part is making http calls. We can avoid that by calculating when new rates are published and returning cached data till then. In addition to storing last used Query string I keep updateDate#version that comes with each cnb response as a topRow. That way if new rates where not published yet I`ll know it and wont store old rates as new ones.

ExchangeRateProvider looks a bit generic so I implemented CnbExchangeRatesProvider pluggable via ICutomExchangeRatesProvider interface.

I did some shortcuts : there is no DI container, no thread sync, no logging. Unit tests project was not part of the solution so i excluded mine from the commit.