### PR TITLE
Task: ExchangeRateUpdater implementation

### DIFF
--- a/jobs/Backend/ExchangeRateUpdater.Tests/CNBExchangeRateProviderTests.cs
+++ b/jobs/Backend/ExchangeRateUpdater.Tests/CNBExchangeRateProviderTests.cs
@@ -1,0 +1,73 @@
+﻿using ExchangeRateUpdater.Providers;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.Protected;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace ExchangeRateUpdater.Tests
+{
+    public class CNBExchangeRateProviderTests
+    {
+        [Fact]
+        public async void GetExchangeRates_ShouldReturnRates_WhenUrlIsCorrect()
+        {
+            //setup             
+            var loggerMock = new Mock<ILogger>();
+
+            var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            handlerMock
+               .Protected()
+               // Setup the PROTECTED method to mock
+               .Setup<Task<HttpResponseMessage>>(
+                  "SendAsync",
+                  ItExpr.IsAny<HttpRequestMessage>(),
+                  ItExpr.IsAny<CancellationToken>()
+               )
+               // prepare the expected response of the mocked http call
+               .ReturnsAsync(new HttpResponseMessage()
+               {
+                   StatusCode = HttpStatusCode.OK,
+                   Content = new StringContent(@"18 Mar 2022 #55
+                                                Country | Currency | Amount | Code | Rate
+                                                Australia | dollar | 1 | AUD | 16.621
+                                                Brazil | real | 1 | BRL | 4.454
+                                                Bulgaria | lev | 1 | BGN | 12.702
+                                                Canada | dollar | 1 | CAD | 17.859
+                                                China | renminbi | 1 | CNY | 3.548
+                                                Croatia | kuna | 1 | HRK | 3.283
+                                                Denmark | krone | 1 | DKK | 3.338
+                                                EMU | euro | 1 | EUR | 24.840
+                                                Hongkong | dollar | 1 | HKD | 2.885
+                                                Hungary | forint | 100 | HUF | 6.618"),
+               })
+               .Verifiable();
+
+            var httpClient = new HttpClient(handlerMock.Object)
+            {
+                BaseAddress = new Uri("https://uri.com"),
+            };
+
+            CNBExchangeRateProvider cnbProvider = new CNBExchangeRateProvider(httpClient, loggerMock.Object);
+
+            //act
+            var rates = await cnbProvider.GetExchangeRates();
+
+            //assert
+            var audExchageReate = new ExchangeRate(new Currency("CZK"), new Currency("AUD"), (decimal)16.621);
+            var hufExchangeRate = new ExchangeRate(new Currency("CZK"), new Currency("HUF"), (decimal)6.618/100);
+
+            Assert.Equal(20, rates.Count()); //20 due to calling fetch 2times for two different sources of CNB rates
+            Assert.Equal(audExchageReate.ToString() ,rates.First().ToString());
+            Assert.Equal(hufExchangeRate.ToString(), rates.Last().ToString());
+
+        }
+    }
+}

--- a/jobs/Backend/ExchangeRateUpdater.Tests/CNBExchangeRateProviderTests.cs
+++ b/jobs/Backend/ExchangeRateUpdater.Tests/CNBExchangeRateProviderTests.cs
@@ -3,7 +3,6 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using Moq.Protected;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;

--- a/jobs/Backend/ExchangeRateUpdater.Tests/ExchangeRateProviderTests.cs
+++ b/jobs/Backend/ExchangeRateUpdater.Tests/ExchangeRateProviderTests.cs
@@ -1,0 +1,64 @@
+﻿using ExchangeRateUpdater.helpers;
+using ExchangeRateUpdater.Providers;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using Xunit;
+
+namespace ExchangeRateUpdater.Tests
+{
+    public class ExchangeRateProviderTests
+    {
+        [Fact]
+        public void GetExchangeRates_ReturnsRatesForGivenCurrencies()
+        {
+
+            //setup
+            var loggerMock = new Mock<ILogger>();
+            var loggerFactoryMock = new Mock<ILoggerFactory>();
+            var httpClientMock = new Mock<HttpClient>();
+            var dateTimeProviderMock = new Mock<IDateTimeProvider>();
+
+            var providedRates = new List<ExchangeRate>
+            {
+                {new ExchangeRate(new Currency("CZK"), new Currency("USD"), 1)},
+                {new ExchangeRate(new Currency("CZK"), new Currency("JPY"), 2)},
+                {new ExchangeRate(new Currency("CZK"), new Currency("RUB"), 3)}
+            };
+
+            var cnbProviderMock = new Mock<IRateProvider>();
+            cnbProviderMock
+                .Setup(s => s.GetExchangeRates())
+                .ReturnsAsync(providedRates);
+
+            var rateProviders = new Dictionary<string, IRateProvider>() { { "CNB", cnbProviderMock.Object } };
+
+            var providerFactoryMock = new Mock<IExchangeRateProviderFactory>();
+            providerFactoryMock
+                .Setup(s => s.GetRateProviders())
+                .Returns(rateProviders);
+
+            ExchangeRateProvider provider = new ExchangeRateProvider(httpClientMock.Object, loggerFactoryMock.Object, providerFactoryMock.Object, dateTimeProviderMock.Object, loggerMock.Object);
+
+          var currecies = new List<Currency>
+          {
+            new Currency("USD"),
+            new Currency("EUR"),
+            new Currency("CZK"),
+            new Currency("JPY"),
+            new Currency("KES"),
+            new Currency("RUB"),
+            new Currency("THB"),
+            new Currency("TRY"),
+            new Currency("XYZ")
+            };
+
+            //act           
+            var rates = provider.GetExchangeRates(currecies).ToList();
+
+            Assert.Equal(3, rates.Count);
+        }
+    }
+}

--- a/jobs/Backend/ExchangeRateUpdater.Tests/ExchangeRateUpdater.Tests.csproj
+++ b/jobs/Backend/ExchangeRateUpdater.Tests/ExchangeRateUpdater.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Moq" Version="4.17.2" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Task\ExchangeRateUpdater.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/jobs/Backend/Task/ExchangeRateProvider.cs
+++ b/jobs/Backend/Task/ExchangeRateProvider.cs
@@ -1,19 +1,107 @@
-﻿using System.Collections.Generic;
+﻿using ExchangeRateUpdater.helpers;
+using ExchangeRateUpdater.Providers;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
 
 namespace ExchangeRateUpdater
 {
     public class ExchangeRateProvider
     {
+        private readonly HttpClient _httpClient;
+        private readonly ILoggerFactory _loggerFactory;
+        private readonly IDateTimeProvider _dateTimeProvider;
+        private readonly ILogger _logger;
+        private readonly IExchangeRateProviderFactory _exchangeRateProviderFactory;
+
+        private const int hoursToReload = 14;
+        private const int minutesToReload = 30;
+
+        private (DateTime dateLoaded, IEnumerable<ExchangeRate> exchangeRates) _exchangeRatesStored;
+
+        /// <summary>
+        /// Construc ExchangeRateProvider 
+        /// </summary>
+        public ExchangeRateProvider() : this(
+            new HttpClient(),
+            LoggerFactory.Create(loggingBuilder => loggingBuilder
+            //TODO: use settings file to set LogLevel (ideally use serilog)
+            .SetMinimumLevel(LogLevel.Trace)
+            .AddConsole()),
+            new DateTimeProvider()
+            )
+        { }
+
+        /// <summary>
+        /// Construct ExhangeRateProvicer
+        /// </summary>
+        /// <param name="httpClient"> httpClient </param>
+        /// <param name="loggerFactory"> loggerFactory that crates ILogger</param>
+        /// <param name="dateTimeProvider"> datetime provider</param>
+        public ExchangeRateProvider(HttpClient httpClient, ILoggerFactory loggerFactory, IDateTimeProvider dateTimeProvider)
+        {
+            _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+            _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
+            _dateTimeProvider = dateTimeProvider ?? throw new ArgumentNullException(nameof(dateTimeProvider));
+            _exchangeRateProviderFactory = new ExchangeRateProviderFactory(httpClient, loggerFactory);
+            _logger = loggerFactory.CreateLogger<ExchangeRateProvider>();
+        }
+
+
+        internal ExchangeRateProvider(HttpClient httpClient, ILoggerFactory loggerFactory, IExchangeRateProviderFactory exchangeRateProviderFactory, IDateTimeProvider dateTimeProvider, ILogger logger)
+        {
+            _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+            _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
+            _exchangeRateProviderFactory = exchangeRateProviderFactory ?? throw new ArgumentNullException(nameof(exchangeRateProviderFactory));
+            _dateTimeProvider = dateTimeProvider ?? throw new ArgumentNullException(nameof(dateTimeProvider));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
         /// <summary>
         /// Should return exchange rates among the specified currencies that are defined by the source. But only those defined
         /// by the source, do not return calculated exchange rates. E.g. if the source contains "CZK/USD" but not "USD/CZK",
         /// do not return exchange rate "USD/CZK" with value calculated as 1 / "CZK/USD". If the source does not provide
         /// some of the currencies, ignore them.
         /// </summary>
+        /// <param name="currencies">List of currencies for which retruns rate</param>
         public IEnumerable<ExchangeRate> GetExchangeRates(IEnumerable<Currency> currencies)
         {
-            return Enumerable.Empty<ExchangeRate>();
+            if (currencies is null) throw new ArgumentNullException(nameof(currencies));
+
+            try
+            {
+                var timeToResetInUtc = _dateTimeProvider.GetUtcDate().Date.AddHours(hoursToReload).AddMinutes(minutesToReload);
+
+                if (_exchangeRatesStored.exchangeRates is null || _exchangeRatesStored.dateLoaded > timeToResetInUtc)
+                {
+                    _logger.LogDebug("Refetching rates");
+                    LoadExchangeRates();
+                }
+
+                return _exchangeRatesStored.exchangeRates.Where(r => currencies.Any(c => c.Code == r.TargetCurrency.Code));
+            }
+            catch(Exception ex)
+            {
+                _logger.LogError($"Failed to get exhange rates ex: {ex}");
+                return null;
+            }
+        }
+
+        private void LoadExchangeRates()
+        {
+            
+            IReadOnlyDictionary<string, IRateProvider> providers = _exchangeRateProviderFactory.GetRateProviders();
+
+            List<ExchangeRate> exchangeRates = new();
+            foreach (IRateProvider provider in providers.Values)
+            {
+                IEnumerable<ExchangeRate> rates = provider.GetExchangeRates().GetAwaiter().GetResult();
+                exchangeRates.AddRange(rates);
+            }
+
+            _exchangeRatesStored = (_dateTimeProvider.GetUtcDate(), exchangeRates);
         }
     }
 }

--- a/jobs/Backend/Task/ExchangeRateUpdater.csproj
+++ b/jobs/Backend/Task/ExchangeRateUpdater.csproj
@@ -19,8 +19,4 @@
 		</AssemblyAttribute>
 	</ItemGroup>
 
-	<ItemGroup>
-	  <Folder Include="Proxies\" />
-	</ItemGroup>
-
 </Project>

--- a/jobs/Backend/Task/ExchangeRateUpdater.csproj
+++ b/jobs/Backend/Task/ExchangeRateUpdater.csproj
@@ -5,4 +5,22 @@
     <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+  </ItemGroup>
+
+	<ItemGroup>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+			<_Parameter1>$(AssemblyName).Tests</_Parameter1>
+		</AssemblyAttribute>		
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+			<_Parameter1>DynamicProxyGenAssembly2</_Parameter1>
+		</AssemblyAttribute>
+	</ItemGroup>
+
+	<ItemGroup>
+	  <Folder Include="Proxies\" />
+	</ItemGroup>
+
 </Project>

--- a/jobs/Backend/Task/ExchangeRateUpdater.sln
+++ b/jobs/Backend/Task/ExchangeRateUpdater.sln
@@ -1,9 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.32112.339
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExchangeRateUpdater", "ExchangeRateUpdater.csproj", "{7B2695D6-D24C-4460-A58E-A10F08550CE0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExchangeRateUpdater", "ExchangeRateUpdater.csproj", "{7B2695D6-D24C-4460-A58E-A10F08550CE0}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{814ABBCE-2AA6-481C-9AE5-847A4EE82B9A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExchangeRateUpdater.Tests", "..\ExchangeRateUpdater.Tests\ExchangeRateUpdater.Tests.csproj", "{3191B5D3-25BF-4CD3-9C8F-9863C2555378}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,8 +19,18 @@ Global
 		{7B2695D6-D24C-4460-A58E-A10F08550CE0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7B2695D6-D24C-4460-A58E-A10F08550CE0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7B2695D6-D24C-4460-A58E-A10F08550CE0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3191B5D3-25BF-4CD3-9C8F-9863C2555378}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3191B5D3-25BF-4CD3-9C8F-9863C2555378}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3191B5D3-25BF-4CD3-9C8F-9863C2555378}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3191B5D3-25BF-4CD3-9C8F-9863C2555378}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{3191B5D3-25BF-4CD3-9C8F-9863C2555378} = {814ABBCE-2AA6-481C-9AE5-847A4EE82B9A}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {FC1DC239-0E9C-4124-BD0E-C5A801479ABC}
 	EndGlobalSection
 EndGlobal

--- a/jobs/Backend/Task/Helpers/DateTimeProvider.cs
+++ b/jobs/Backend/Task/Helpers/DateTimeProvider.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace ExchangeRateUpdater.helpers
 {

--- a/jobs/Backend/Task/Helpers/DateTimeProvider.cs
+++ b/jobs/Backend/Task/Helpers/DateTimeProvider.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ExchangeRateUpdater.helpers
+{
+    public class DateTimeProvider : IDateTimeProvider
+    {
+        public DateTime GetUtcDate()
+        {
+            return DateTime.UtcNow;
+        }
+    }
+}

--- a/jobs/Backend/Task/Helpers/IDateTimeProvider.cs
+++ b/jobs/Backend/Task/Helpers/IDateTimeProvider.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace ExchangeRateUpdater.helpers
+{
+    public interface IDateTimeProvider
+    {
+        public DateTime GetUtcDate();
+    }
+}

--- a/jobs/Backend/Task/Providers/CNBExchangeRateProvider/CNBExchangeRateProvider.cs
+++ b/jobs/Backend/Task/Providers/CNBExchangeRateProvider/CNBExchangeRateProvider.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace ExchangeRateUpdater.Providers
+{
+    internal class CNBExchangeRateProvider : IRateProvider
+    {
+        private const string cnbRatesMainUrl = "https://www.cnb.cz/en/financial-markets/foreign-exchange-market/central-bank-exchange-rate-fixing/central-bank-exchange-rate-fixing/daily.txt";
+        private const string cnbRatesOthersUrl = "https://www.cnb.cz/en/financial-markets/foreign-exchange-market/fx-rates-of-other-currencies/fx-rates-of-other-currencies/fx_rates.txt?year=2022&month=2";
+        public string BaseCurrencyCode => "CZK";
+
+        private readonly HttpClient _httpClient;
+        private readonly ILogger _logger;
+
+
+        public CNBExchangeRateProvider(HttpClient client, ILogger<CNBExchangeRateProvider> logger)
+        {
+            _httpClient = client;
+            _logger = logger;
+        }
+
+        public CNBExchangeRateProvider(HttpClient client, ILogger logger)
+        {
+            _httpClient = client;
+            _logger = logger;
+        }
+
+        public async Task<IEnumerable<ExchangeRate>> GetExchangeRates()
+        {
+            _logger.LogDebug("Geting exhange rates");
+            try
+            {
+                string mainRates = await FetchRates(cnbRatesMainUrl);
+                string otherRates = await FetchRates(cnbRatesOthersUrl);
+
+                var mainRatesParsed = ParseRates(mainRates);
+                var otherRatesParsed = ParseRates(otherRates);
+
+                return mainRatesParsed.Concat(otherRatesParsed);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Failed to get exhange rates ex:{ex} for {BaseCurrencyCode}");
+                return null;
+            }
+
+        }
+         
+        private async Task<string> FetchRates(string url)
+        {
+            _logger.LogDebug($"Fetching rates from {url}");
+            try
+            {
+                HttpResponseMessage response = await _httpClient.GetAsync(url);
+                response.EnsureSuccessStatusCode();
+                string rates = await response.Content.ReadAsStringAsync();
+                return rates;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Failed to fetch rates ex: {ex}, from: {url}");
+                return null;
+            }
+
+        }
+
+        private IEnumerable<ExchangeRate> ParseRates(string rates)
+        {
+            _logger.LogDebug($"Parsing rates: {rates}");
+            try
+            { 
+                var baseCurrency = new Currency(BaseCurrencyCode);
+
+                IEnumerable<ExchangeRate> exchangeRates = rates.Replace(" ", string.Empty).Split("\n").Skip(2).Where(x => x.Length > 0).Select(x =>
+                {
+                    return ParseRate(x, baseCurrency);
+                }).Where(x => x is not null);
+                return exchangeRates;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Failed to parse rates ex: {ex}, for rates: {rates}");
+                return null;
+            }
+        }
+
+        private ExchangeRate ParseRate(string rateAsString, Currency baseCurrency)
+        {      
+            try
+            {
+                var i = rateAsString.Split("|");
+                var rate = decimal.Parse(i[4]);
+                var anmount = int.Parse(i[2]);
+                var actualRate = rate / anmount;
+                return new ExchangeRate(baseCurrency, new Currency(i[3]), actualRate);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Error parsing currency {ex.Message} for currency: {rateAsString}");
+                return null;
+            }
+
+        }
+    }
+}

--- a/jobs/Backend/Task/Providers/ExchangeRateProviderFactory.cs
+++ b/jobs/Backend/Task/Providers/ExchangeRateProviderFactory.cs
@@ -3,8 +3,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace ExchangeRateUpdater.Providers
 {

--- a/jobs/Backend/Task/Providers/ExchangeRateProviderFactory.cs
+++ b/jobs/Backend/Task/Providers/ExchangeRateProviderFactory.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ExchangeRateUpdater.Providers
+{
+    internal class ExchangeRateProviderFactory : IExchangeRateProviderFactory
+    {
+        private readonly IReadOnlyDictionary<string, IRateProvider> _rateProviders;
+
+        public ExchangeRateProviderFactory(HttpClient httpClient, ILoggerFactory loggerFactory)
+        {
+            var exchangeRateProviderType = typeof(IRateProvider);
+
+            IEnumerable<Type> allProviders = AppDomain.CurrentDomain.GetAssemblies().SelectMany(x => x.GetTypes())
+                .Where(x => exchangeRateProviderType.IsAssignableFrom(x) && !x.IsInterface && !x.IsAbstract);
+
+            IEnumerable<object> rateProviders = allProviders.Select(p =>
+            {
+                return Activator.CreateInstance(p, httpClient, loggerFactory.CreateLogger(p.Name));
+            });
+
+            _rateProviders = rateProviders.Cast<IRateProvider>().ToDictionary(p => p.BaseCurrencyCode, p=>p);
+        }
+
+        public IReadOnlyDictionary<string, IRateProvider> GetRateProviders()
+        {
+            return _rateProviders;
+        }
+
+    }
+}

--- a/jobs/Backend/Task/Providers/IExchangeRateProviderFactory.cs
+++ b/jobs/Backend/Task/Providers/IExchangeRateProviderFactory.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace ExchangeRateUpdater.Providers
+{
+    internal interface IExchangeRateProviderFactory
+    {
+        public IReadOnlyDictionary<string, IRateProvider> GetRateProviders();
+    }
+}

--- a/jobs/Backend/Task/Providers/IRateProvider.cs
+++ b/jobs/Backend/Task/Providers/IRateProvider.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace ExchangeRateUpdater.Providers
+{
+    internal interface IRateProvider
+    {
+        Task<IEnumerable<ExchangeRate>> GetExchangeRates();
+        public string BaseCurrencyCode { get; }
+    }
+}


### PR DESCRIPTION
Some improvements I would add after further discussion with my reviewer.
1. Not having separate class library for exchange rate providers - 
	Currency and Exchange rate models might be used else where and I dont want to break contracts due to namespace changes and using generics would be too much for this project
2. Refreshing rate storage - currently works OK for CNB but if there were more providers, each should specify its refresh condtion and I would use IMemoryCache for storage, right now private property is enough since our api is synchronnous we have no need for thread safety
3. Using factory to get CNB exchange rate provider - since in console app we dont have DI setup by default this was an obvious choice.
	I could have set up IHost using HostBuilder and configure services, but that would mean changes to Program.cs which I wanted to avoid in this task.
4. For unit testing internal classes I used InternalsVisibleTo assembly attribute.
5. I should have created HttpClient proxy for easier testing.
6. Would be nice to actually use cancelation tokens since HttpClient supports them.
7. For 'real' PR even though it was requested I would add more Unit tests, but those present prove the testability of the solution.