### PR TITLE
roy ibarra sre task

### DIFF
--- a/jobs/SRE/regressed_endpoints.py
+++ b/jobs/SRE/regressed_endpoints.py
@@ -1,0 +1,42 @@
+
+#!/usr/bin/env python3
+
+import json
+import pandas as pd
+
+# list of slow requests
+slow_endpoints = []
+
+# read the logs.txt file
+def read_logs() :
+    try:
+        with open('logs.txt') as file:
+            for line in file:
+                # convert string to dictionary
+                res_dic = json.loads(line.rstrip())
+                if res_dic['Duration'] >= 200:
+                    # create datetime object from the string
+                    ts = pd.Timestamp(res_dic['TimeStamp'])
+                    # update the TimeStamp with a rounded time
+                    res_dic['TimeStamp'] = ts.round(freq='5T').strftime('%Y-%m-%d %X')
+                    # Remove this key to easily remove duplicates later on
+                    del res_dic['Duration']
+                    slow_endpoints.append(res_dic)
+        return True
+    except:
+        print("Error when reading logs file")
+        return False
+
+# save results to a file instead of printing to standard output
+def save_to_file () :
+    # remove duplicate requests to show only one request per 5min timeframe
+    d_unique = pd.DataFrame(slow_endpoints).drop_duplicates().to_dict('records')
+    with open('slow_endpoints.txt', 'w') as file:
+        for item in d_unique:
+            line = f"{item['TimeStamp']} \t {item['Endpoint']}\n"
+            file.write(f"{line}")
+
+if __name__ == "__main__":
+    
+    if read_logs() :
+        save_to_file ()


### PR DESCRIPTION
For this scenario I'm considering slow endpoints those requests whose duration are more than 200 milliseconds.

This python script reads the logs.txt file and converts each line (request) to a dictionary so that we better manipulate the data. The result is a list of such requests.

For every slow request I'm using the pandas library to easily round the timestamp to 5 minutes.

The list of slow endpoints is then save to a file instead of printing them in standard output.

Before the list of slow endpoints is saved to the file, I decided to remove duplicates as there were too many results for the same endpoint having the same rounded timestamp. However, we could use the full list of slow endpoints to analyze the number of requests made and determine if the number of request can contribute to the endpoint being slow, if so, scale the resources horizontally or vertically.

The approach is to work only with the information we have in the logs.txt file. We could take into consideration other status codes that indicate a failure (status code 400 or greater) and try to isolate what is causing a specific HTTP error.

We could also work with the number of requests handled or how many requests are from a specific IP address/location and consider using some kind of caching.

When looking at the results of the script we can think which of these endpoints need to route the request to other items such as querying a database and look for improvements around there.