### PR TITLE
Implemented the ExchangeRateUpdater.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@
 node_modules
 bower_components
 npm-debug.log
+
+jobs/Backend/Task/.vs/

--- a/jobs/Backend/ExchangeRateUpdaterTests/CnbExchangeRateDataStringParserTests.cs
+++ b/jobs/Backend/ExchangeRateUpdaterTests/CnbExchangeRateDataStringParserTests.cs
@@ -1,0 +1,41 @@
+using ExchangeRateUpdater;
+using ExchangeRateUpdater.CzechNationalBank;
+using ExchangeRateUpdater.Models;
+using FluentAssertions;
+
+namespace ExchangeRateUpdaterTests
+{
+	[TestClass]
+	public class CnbExchangeRateDataStringParserTests
+	{
+		private IDataStringParser<IEnumerable<ExchangeRate>> cnbExchangeRateDataStringParser;
+
+		[TestInitialize]
+		public void TestInitialize()
+		{
+			cnbExchangeRateDataStringParser = new CnbExchangeRateDataStringParser();
+		}
+
+		[TestMethod]
+		public void Parse_CorrectlyParsesTheCnbExchangeRateTextFormat()
+		{
+			var input = string.Join(
+				"\n",
+				"16 Sep 2022 #181",
+				"Country|Currency|Amount|Code|Rate",
+				"Australia|dollar|1|AUD|16.446",
+				"Hungary|forint|100|HUF|6.063",
+				"Indonesia|rupiah|1000|IDR|1.646"
+			);
+
+			var parsed = cnbExchangeRateDataStringParser.Parse(input);
+
+			parsed.Should().BeEquivalentTo(new[]
+			{
+				new ExchangeRate(new Currency("AUD"), new Currency("CZK"), 16.446M),
+				new ExchangeRate(new Currency("HUF"), new Currency("CZK"), 0.06063M),
+				new ExchangeRate(new Currency("IDR"), new Currency("CZK"), 0.001646M),
+			}, options => options.WithStrictOrdering());
+		}
+	}
+}

--- a/jobs/Backend/ExchangeRateUpdaterTests/ExchangeRateProviderTests.cs
+++ b/jobs/Backend/ExchangeRateUpdaterTests/ExchangeRateProviderTests.cs
@@ -1,0 +1,80 @@
+using ExchangeRateUpdater;
+using ExchangeRateUpdater.Models;
+using ExchangeRateUpdater.Services;
+using FluentAssertions;
+using Moq;
+
+namespace ExchangeRateUpdaterTests
+{
+	[TestClass]
+	public class ExchangeRateProviderTests
+	{
+		private Mock<IWebRequestService> mockWebRequestService;
+		private Mock<IDataStringParser<IEnumerable<ExchangeRate>>> mockDataStringParser;
+		private IExchangeRateProvider exchangeRateProvider;
+
+		[TestInitialize]
+		public void TestInitialize()
+		{
+			mockWebRequestService = new Mock<IWebRequestService>();
+			mockDataStringParser = new Mock<IDataStringParser<IEnumerable<ExchangeRate>>>(MockBehavior.Strict);
+			exchangeRateProvider = new ExchangeRateProvider(mockWebRequestService.Object, mockDataStringParser.Object);
+		}
+
+		[TestMethod]
+		public async Task GetExchangeRatesAsync_ReturnsOnlyTheRatesAvailableInTheDataSource()
+		{
+			var currencies = new List<Currency>
+			{
+				new Currency("ABC"),
+				new Currency("DEF"),
+				new Currency("GHI")
+			};
+
+			mockDataStringParser
+				.Setup(m => m.Parse(It.IsAny<string>()))
+				.Returns(new[]
+				{
+					new ExchangeRate(new Currency("ABC"), new Currency("XYZ"), 1.23M),
+					new ExchangeRate(new Currency("GHI"), new Currency("XYZ"), 6.78M)
+				});
+
+			var actualExchangeRates = await exchangeRateProvider.GetExchangeRatesAsync(currencies).ConfigureAwait(false);
+
+			actualExchangeRates.ToList().Should()
+				.BeEquivalentTo(new[]
+				{
+					new ExchangeRate(new Currency("ABC"), new Currency("XYZ"), 1.23M),
+					new ExchangeRate(new Currency("GHI"), new Currency("XYZ"), 6.78M)
+				}, options => options.WithStrictOrdering());
+		}
+
+		[TestMethod]
+		public async Task GetExchangeRatesAsync_DoesNotReturnRatesNotSpecifiedInCurrenciesParameter()
+		{
+			var currencies = new List<Currency>
+			{
+				new Currency("ABC"),
+				new Currency("GHI")
+			};
+
+			mockDataStringParser
+				.Setup(m => m.Parse(It.IsAny<string>()))
+				.Returns(new[]
+				{
+					new ExchangeRate(new Currency("ABC"), new Currency("XYZ"), 1.23M),
+					new ExchangeRate(new Currency("DEF"), new Currency("XYZ"), 3.45M),
+					new ExchangeRate(new Currency("GHI"), new Currency("XYZ"), 6.78M)
+				});
+
+			var actualExchangeRates = await exchangeRateProvider.GetExchangeRatesAsync(currencies).ConfigureAwait(false);
+
+			actualExchangeRates.ToList().Should()
+				.BeEquivalentTo(new[]
+				{
+					new ExchangeRate(new Currency("ABC"), new Currency("XYZ"), 1.23M),
+					new ExchangeRate(new Currency("GHI"), new Currency("XYZ"), 6.78M)
+				}, options => options.WithStrictOrdering());
+		}
+	}
+}

--- a/jobs/Backend/ExchangeRateUpdaterTests/ExchangeRateUpdaterTests.csproj
+++ b/jobs/Backend/ExchangeRateUpdaterTests/ExchangeRateUpdaterTests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8">
+      <TreatAsUsed>true</TreatAsUsed>
+    </PackageReference>
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Task\ExchangeRateUpdater.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/jobs/Backend/ExchangeRateUpdaterTests/MethodInterceptor.cs
+++ b/jobs/Backend/ExchangeRateUpdaterTests/MethodInterceptor.cs
@@ -1,0 +1,26 @@
+﻿using Castle.DynamicProxy;
+
+namespace ExchangeRateUpdaterTests
+{
+	internal class MethodInterceptor : IInterceptor
+	{
+		private string methodName;
+		private readonly Action<IInvocation> onIntercept;
+
+		public MethodInterceptor(string methodName, Action<IInvocation> onIntercept)
+		{
+			this.methodName = methodName;
+			this.onIntercept = onIntercept;
+		}
+
+		public void Intercept(IInvocation invocation)
+		{
+			if (invocation.Method.Name == methodName)
+			{
+				onIntercept(invocation);
+			}
+
+			invocation.Proceed();
+		}
+	}
+}

--- a/jobs/Backend/ExchangeRateUpdaterTests/OfflineIntegrationTests.cs
+++ b/jobs/Backend/ExchangeRateUpdaterTests/OfflineIntegrationTests.cs
@@ -1,0 +1,114 @@
+﻿using ExchangeRateUpdater;
+using ExchangeRateUpdater.Services;
+using FluentAssertions;
+using Moq;
+using Ninject;
+
+namespace ExchangeRateUpdaterTests
+{
+	[TestClass]
+	public class OfflineIntegrationTests
+	{
+		private Mock<IWebRequestService> mockWebRequestService;
+		private Mock<ILogger> mockLogger;
+
+		private IKernel kernel;
+		private Program program;
+
+		[TestInitialize]
+		public void TestInitialize()
+		{
+			kernel = new StandardKernel(new DependencyInjectionConfiguration());
+
+			mockWebRequestService = new Mock<IWebRequestService>();
+			mockLogger = new Mock<ILogger>(MockBehavior.Strict);
+
+			kernel.Rebind<IWebRequestService>().ToConstant(mockWebRequestService.Object);
+			kernel.Rebind<ILogger>().ToConstant(mockLogger.Object);
+
+			program = kernel.Get<Program>();
+		}
+
+		[TestMethod]
+		public async Task ExchangeRateUpdater_SuccessFlow()
+		{
+			var actualInfoMessages = new List<string>();
+
+			mockWebRequestService
+				.Setup(m => m.GetAsStringAsync(It.Is<Uri>(uri => uri == ExchangeRateProvider.CnbExchangeRateDataUri)))
+				.ReturnsAsync(string.Join(
+					Environment.NewLine,
+					"16 Sep 2022 #181",
+					"Country|Currency|Amount|Code|Rate",
+					"Australia|dollar|1|AUD|16.446",
+					"Brazil|real|1|BRL|4.683",
+					"Bulgaria|lev|1|BGN|12.566",
+					"Canada|dollar|1|CAD|18.518",
+					"China|renminbi|1|CNY|3.510",
+					"Croatia|kuna|1|HRK|3.256",
+					"Denmark|krone|1|DKK|3.294",
+					"EMU|euro|1|EUR|24.495",
+					"Hongkong|dollar|1|HKD|3.135",
+					"Hungary|forint|100|HUF|6.063",
+					"Iceland|krona|100|ISK|17.711",
+					"IMF|SDR|1|XDR|31.862",
+					"India|rupee|100|INR|30.862",
+					"Indonesia|rupiah|1000|IDR|1.646",
+					"Israel|new shekel|1|ILS|7.148",
+					"Japan|yen|100|JPY|17.183",
+					"Malaysia|ringgit|1|MYR|5.426",
+					"Mexico|peso|1|MXN|1.224",
+					"New Zealand|dollar|1|NZD|14.653",
+					"Norway|krone|1|NOK|2.401",
+					"Philippines|peso|100|PHP|42.886",
+					"Poland|zloty|1|PLN|5.196",
+					"Romania|leu|1|RON|4.976",
+					"Singapore|dollar|1|SGD|17.464",
+					"South Africa|rand|1|ZAR|1.392",
+					"South Korea|won|100|KRW|1.770",
+					"Sweden|krona|1|SEK|2.277",
+					"Switzerland|franc|1|CHF|25.567",
+					"Thailand|baht|100|THB|66.551",
+					"Turkey|lira|1|TRY|1.346",
+					"United Kingdom|pound|1|GBP|28.030",
+					"USA|dollar|1|USD|24.606")
+				);
+			mockLogger
+				.Setup(m => m.LogInfoAsync(It.IsAny<string>()))
+				.Callback<string>(actualInfoMessages.Add)
+				.Returns(Task.CompletedTask);
+
+			await program.RunAsync().ConfigureAwait(false);
+
+			actualInfoMessages.Should()
+				.HaveCount(6).And
+				.ContainInOrder(
+					"Successfully retrieved 5 exchange rates:",
+					$"USD/CZK={24.606M}",
+					$"EUR/CZK={24.495M}",
+					$"JPY/CZK={0.17183M}",
+					$"THB/CZK={0.66551M}",
+					$"TRY/CZK={1.346M}"
+				);
+		}
+
+		[TestMethod]
+		public async Task ExchangeRateUpdater_FailureFlow()
+		{
+			var actualErrorMessages = new List<string>();
+			var exceptionMessage = "ExchangeRateProvider exception";
+
+			mockWebRequestService
+				.Setup(m => m.GetAsStringAsync(It.Is<Uri>(uri => uri == ExchangeRateProvider.CnbExchangeRateDataUri)))
+				.ThrowsAsync(new Exception(exceptionMessage));
+			mockLogger
+				.Setup(m => m.LogErrorAsync(It.IsAny<string>()))
+				.Callback<string>(actualErrorMessages.Add)
+				.Returns(Task.CompletedTask);
+
+			await program.RunAsync().ConfigureAwait(false);
+
+			actualErrorMessages.Should().BeEquivalentTo($"Could not retrieve exchange rates: '{exceptionMessage}'.");
+		}
+	}
+}

--- a/jobs/Backend/ExchangeRateUpdaterTests/OnlineIntegrationTests.cs
+++ b/jobs/Backend/ExchangeRateUpdaterTests/OnlineIntegrationTests.cs
@@ -1,0 +1,48 @@
+﻿using Castle.DynamicProxy;
+using ExchangeRateUpdater;
+using FluentAssertions;
+using Ninject;
+
+namespace ExchangeRateUpdaterTests
+{
+	[TestClass]
+	[TestCategory("Online")]
+	public class OnlineIntegrationTests
+	{
+		private static readonly ProxyGenerator proxyGenerator = new ProxyGenerator();
+
+		private IKernel kernel;
+		private ILogger logger;
+		private Program program;
+
+		[TestInitialize]
+		public void TestInitialize()
+		{
+			kernel = new StandardKernel(new DependencyInjectionConfiguration());
+		}
+
+		[TestMethod]
+		public async Task ExchangeRateUpdater_SmokeTest()
+		{
+			var logInfoMessages = new List<string>();
+
+			logger = kernel.Get<ILogger>();
+
+			var logInfoAsyncInterceptor = new MethodInterceptor(nameof(ILogger.LogInfoAsync), invocation =>
+			{
+				logInfoMessages.Add((string)invocation.Arguments[0]);
+			});
+			var proxyLogger = proxyGenerator.CreateInterfaceProxyWithTarget(logger, logInfoAsyncInterceptor);
+
+			kernel.Rebind<ILogger>().ToConstant(proxyLogger);
+			program = kernel.Get<Program>();
+
+			await program.RunAsync().ConfigureAwait(false);
+
+			logInfoMessages.Should()
+				.HaveCountGreaterThan(1);
+			logInfoMessages[0].Should()
+				.MatchRegex("Successfully retrieved \\d{1,} exchange rates:");
+		}
+	}
+}

--- a/jobs/Backend/ExchangeRateUpdaterTests/Usings.cs
+++ b/jobs/Backend/ExchangeRateUpdaterTests/Usings.cs
@@ -1,0 +1,1 @@
+global using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/jobs/Backend/Task/CzechNationalBank/CnbExchangeRateDataStringParser.cs
+++ b/jobs/Backend/Task/CzechNationalBank/CnbExchangeRateDataStringParser.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using ExchangeRateUpdater.Models;
+
+namespace ExchangeRateUpdater.CzechNationalBank
+{
+	internal class CnbExchangeRateDataStringParser : IDataStringParser<IEnumerable<ExchangeRate>>
+	{
+		private const string targetCurrencyCode = "CZK";
+
+		public IEnumerable<ExchangeRate> Parse(string input)
+		{
+			var lines = input.Split("\n", StringSplitOptions.RemoveEmptyEntries);
+
+			return lines
+				.Skip(2)
+				.Select(ParseExchangeRateLine)
+				.Where(line => line != null);
+		}
+
+		private static ExchangeRate ParseExchangeRateLine(string line)
+		{
+			var cells = line.Split('|');
+			var rawSourceAmount = cells[2];
+			var rawCurrencyCode = cells[3];
+			var rawTargetAmount = cells[4];
+
+			if (decimal.TryParse(rawSourceAmount, out var sourceAmount) && decimal.TryParse(rawTargetAmount, NumberStyles.Currency, CultureInfo.InvariantCulture, out var targetAmount))
+			{
+				var rate = targetAmount / sourceAmount;
+
+				return new ExchangeRate(new Currency(rawCurrencyCode), new Currency(targetCurrencyCode), rate);
+			}
+
+			return null;
+		}
+	}
+}

--- a/jobs/Backend/Task/DependencyInjectionConfiguration.cs
+++ b/jobs/Backend/Task/DependencyInjectionConfiguration.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+using ExchangeRateUpdater.CzechNationalBank;
+using ExchangeRateUpdater.Models;
+using ExchangeRateUpdater.Services;
+using Ninject.Modules;
+
+namespace ExchangeRateUpdater
+{
+	internal class DependencyInjectionConfiguration : NinjectModule
+	{
+		public override void Load()
+		{
+			Bind<IExchangeRateProvider>().To<ExchangeRateProvider>();
+			Bind<IDataStringParser<IEnumerable<ExchangeRate>>>().To<CnbExchangeRateDataStringParser>();
+			Bind<ILogger>().To<Logger>();
+			Bind<IWebRequestService>().To<WebRequestService>();
+		}
+	}
+}

--- a/jobs/Backend/Task/ExchangeRateUpdater.csproj
+++ b/jobs/Backend/Task/ExchangeRateUpdater.csproj
@@ -5,4 +5,8 @@
     <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Ninject" Version="3.3.6" />
+  </ItemGroup>
+
 </Project>

--- a/jobs/Backend/Task/ExchangeRateUpdater.sln
+++ b/jobs/Backend/Task/ExchangeRateUpdater.sln
@@ -1,9 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32819.101
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExchangeRateUpdater", "ExchangeRateUpdater.csproj", "{7B2695D6-D24C-4460-A58E-A10F08550CE0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExchangeRateUpdater", "ExchangeRateUpdater.csproj", "{7B2695D6-D24C-4460-A58E-A10F08550CE0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExchangeRateUpdaterTests", "..\ExchangeRateUpdaterTests\ExchangeRateUpdaterTests.csproj", "{5F655A10-4235-4FAA-B4BE-114B787ECF0D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,8 +17,15 @@ Global
 		{7B2695D6-D24C-4460-A58E-A10F08550CE0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7B2695D6-D24C-4460-A58E-A10F08550CE0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7B2695D6-D24C-4460-A58E-A10F08550CE0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5F655A10-4235-4FAA-B4BE-114B787ECF0D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5F655A10-4235-4FAA-B4BE-114B787ECF0D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5F655A10-4235-4FAA-B4BE-114B787ECF0D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5F655A10-4235-4FAA-B4BE-114B787ECF0D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {FF11C5DA-2E01-4825-AB92-4022FA1B9DB8}
 	EndGlobalSection
 EndGlobal

--- a/jobs/Backend/Task/IDataStringParser.cs
+++ b/jobs/Backend/Task/IDataStringParser.cs
@@ -1,0 +1,7 @@
+﻿namespace ExchangeRateUpdater
+{
+	internal interface IDataStringParser<T>
+	{
+		T Parse(string input);
+	}
+}

--- a/jobs/Backend/Task/IExchangeRateProvider.cs
+++ b/jobs/Backend/Task/IExchangeRateProvider.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using ExchangeRateUpdater.Models;
+
+namespace ExchangeRateUpdater
+{
+	internal interface IExchangeRateProvider
+	{
+		Task<IEnumerable<ExchangeRate>> GetExchangeRatesAsync(IEnumerable<Currency> currencies);
+	}
+}

--- a/jobs/Backend/Task/ILogger.cs
+++ b/jobs/Backend/Task/ILogger.cs
@@ -1,0 +1,10 @@
+﻿using System.Threading.Tasks;
+
+namespace ExchangeRateUpdater
+{
+	internal interface ILogger
+	{
+		Task LogInfoAsync(string message);
+		Task LogErrorAsync(string message);
+	}
+}

--- a/jobs/Backend/Task/IWebRequestService.cs
+++ b/jobs/Backend/Task/IWebRequestService.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace ExchangeRateUpdater
+{
+	internal interface IWebRequestService
+	{
+		Task<string> GetAsStringAsync(Uri uriToGet);
+	}
+}

--- a/jobs/Backend/Task/Models/Currency.cs
+++ b/jobs/Backend/Task/Models/Currency.cs
@@ -1,0 +1,20 @@
+﻿namespace ExchangeRateUpdater.Models
+{
+	internal class Currency
+	{
+		public Currency(string code)
+		{
+			Code = code;
+		}
+
+		/// <summary>
+		/// Three-letter ISO 4217 code of the currency.
+		/// </summary>
+		public string Code { get; }
+
+		public override string ToString()
+		{
+			return Code;
+		}
+	}
+}

--- a/jobs/Backend/Task/Models/ExchangeRate.cs
+++ b/jobs/Backend/Task/Models/ExchangeRate.cs
@@ -1,0 +1,23 @@
+﻿namespace ExchangeRateUpdater.Models
+{
+	internal class ExchangeRate
+	{
+		public ExchangeRate(Currency sourceCurrency, Currency targetCurrency, decimal value)
+		{
+			SourceCurrency = sourceCurrency;
+			TargetCurrency = targetCurrency;
+			Value = value;
+		}
+
+		public Currency SourceCurrency { get; }
+
+		public Currency TargetCurrency { get; }
+
+		public decimal Value { get; }
+
+		public override string ToString()
+		{
+			return $"{SourceCurrency}/{TargetCurrency}={Value}";
+		}
+	}
+}

--- a/jobs/Backend/Task/Program.cs
+++ b/jobs/Backend/Task/Program.cs
@@ -1,43 +1,66 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using ExchangeRateUpdater.Models;
+using Ninject;
+
+[assembly: InternalsVisibleTo("ExchangeRateUpdaterTests")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
 
 namespace ExchangeRateUpdater
 {
-    public static class Program
-    {
-        private static IEnumerable<Currency> currencies = new[]
-        {
-            new Currency("USD"),
-            new Currency("EUR"),
-            new Currency("CZK"),
-            new Currency("JPY"),
-            new Currency("KES"),
-            new Currency("RUB"),
-            new Currency("THB"),
-            new Currency("TRY"),
-            new Currency("XYZ")
-        };
+	internal class Program
+	{
+		private static readonly IEnumerable<Currency> currencies = new[]
+		{
+			new Currency("USD"),
+			new Currency("EUR"),
+			new Currency("CZK"),
+			new Currency("JPY"),
+			new Currency("KES"),
+			new Currency("RUB"),
+			new Currency("THB"),
+			new Currency("TRY"),
+			new Currency("XYZ")
+		};
+		private readonly IExchangeRateProvider exchangeRateProvider;
+		private readonly ILogger logger;
 
-        public static void Main(string[] args)
-        {
-            try
-            {
-                var provider = new ExchangeRateProvider();
-                var rates = provider.GetExchangeRates(currencies);
+		public Program(IExchangeRateProvider exchangeRateProvider, ILogger logger)
+		{
+			this.exchangeRateProvider = exchangeRateProvider;
+			this.logger = logger;
+		}
 
-                Console.WriteLine($"Successfully retrieved {rates.Count()} exchange rates:");
-                foreach (var rate in rates)
-                {
-                    Console.WriteLine(rate.ToString());
-                }
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine($"Could not retrieve exchange rates: '{e.Message}'.");
-            }
+		public static async Task Main()
+		{
+			var kernel = new StandardKernel(new DependencyInjectionConfiguration());
+			var program = kernel.Get<Program>();
 
-            Console.ReadLine();
-        }
-    }
+			await program.RunAsync().ConfigureAwait(false);
+
+			Console.ReadLine();
+		}
+
+		public async Task RunAsync()
+		{
+			try
+			{
+				var rates = (await exchangeRateProvider.GetExchangeRatesAsync(currencies).ConfigureAwait(false)).ToList();
+
+				await logger.LogInfoAsync($"Successfully retrieved {rates.Count} exchange rates:").ConfigureAwait(false);
+
+				foreach (var rate in rates)
+				{
+					await logger.LogInfoAsync(rate.ToString()).ConfigureAwait(false);
+				}
+			}
+			catch (Exception e)
+			{
+				await logger.LogErrorAsync($"Could not retrieve exchange rates: '{e.Message}'.").ConfigureAwait(false);
+			}
+		}
+	}
 }

--- a/jobs/Backend/Task/Services/ExchangeRateProvider.cs
+++ b/jobs/Backend/Task/Services/ExchangeRateProvider.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using ExchangeRateUpdater.Models;
+
+namespace ExchangeRateUpdater.Services
+{
+	internal class ExchangeRateProvider : IExchangeRateProvider
+	{
+		internal static readonly Uri CnbExchangeRateDataUri = new Uri("https://www.cnb.cz/en/financial-markets/foreign-exchange-market/central-bank-exchange-rate-fixing/central-bank-exchange-rate-fixing/daily.txt");
+
+		private readonly IWebRequestService webRequestService;
+		private readonly IDataStringParser<IEnumerable<ExchangeRate>> cnbExcahngeRateDataStringParser;
+
+		public ExchangeRateProvider(
+			IWebRequestService webRequestService,
+			IDataStringParser<IEnumerable<ExchangeRate>> cnbExcahngeRateDataStringParser)
+		{
+			this.webRequestService = webRequestService;
+			this.cnbExcahngeRateDataStringParser = cnbExcahngeRateDataStringParser;
+		}
+
+		/// <summary>
+		/// Returns exchange rates among the specified currencies that are defined by the source. If the source does not provide
+		/// some of the specified currencies, they will not be included in the result.
+		/// </summary>
+		public async Task<IEnumerable<ExchangeRate>> GetExchangeRatesAsync(IEnumerable<Currency> currencies)
+		{
+			var rawExchangeRateData = await webRequestService.GetAsStringAsync(CnbExchangeRateDataUri).ConfigureAwait(false);
+
+			var parsedExchangeRateData = cnbExcahngeRateDataStringParser.Parse(rawExchangeRateData);
+
+			return currencies
+				.Select(currency =>
+					parsedExchangeRateData.FirstOrDefault(exchangeRate =>
+						exchangeRate.SourceCurrency.Code == currency.Code
+					)
+				)
+				.Where(exchangeRate => exchangeRate != null);
+		}
+	}
+}

--- a/jobs/Backend/Task/Services/Logger.cs
+++ b/jobs/Backend/Task/Services/Logger.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace ExchangeRateUpdater.Services
+{
+	internal class Logger : ILogger
+	{
+		public async Task LogInfoAsync(string message)
+		{
+			await Console.Out.WriteLineAsync(message).ConfigureAwait(false);
+		}
+
+		public async Task LogErrorAsync(string message)
+		{
+			await Console.Error.WriteLineAsync(message).ConfigureAwait(false);
+		}
+	}
+}

--- a/jobs/Backend/Task/Services/WebRequestService.cs
+++ b/jobs/Backend/Task/Services/WebRequestService.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace ExchangeRateUpdater.Services
+{
+	internal class WebRequestService : IWebRequestService
+	{
+		private readonly HttpClient httpClient;
+
+		public WebRequestService(HttpClient httpClient)
+		{
+			this.httpClient = httpClient;
+		}
+
+		public async Task<string> GetAsStringAsync(Uri uriToGet)
+		{
+			return await httpClient.GetStringAsync(uriToGet).ConfigureAwait(false);
+		}
+	}
+}


### PR DESCRIPTION
- Added dependency injection.
- Added services to fetch and parse exchange rate data from the CNB data source.
- Moved the Console.WriteLine statements behind an ILogger interface so they can be intercepted during testing and to allow additional log destinations to be easily added in the future.
- Added unit tests.
- Added integration tests that mock the CNB data source as well as an integration tests that depends on the real data source.
- Added the MethodInterceptor which allows method calls to be intercepted, without mocking, during testing an additional actions to be taken such as asserting the correct arguments were supplied. 