### PR TITLE
Alberto Acuña - .Net challenge

### DIFF
--- a/jobs/Backend/ExchangeRateTest/CZKExchangeRateApiProviderTest.cs
+++ b/jobs/Backend/ExchangeRateTest/CZKExchangeRateApiProviderTest.cs
@@ -1,0 +1,55 @@
+using ExchangeRateUpdater;
+using Moq;
+using Moq.Protected;
+
+namespace ExchangeRateTest;
+
+public class CZKExchangeRateApiProviderTest
+{
+    private readonly Mock<CZKExchangeRateApiProvider> _mockApiProvider;
+    private readonly ExchangeRateCNBResult eur_rate;
+    private readonly ExchangeRateCNBResult jpy_rate;
+
+    public CZKExchangeRateApiProviderTest()
+    {
+        eur_rate = new ExchangeRateCNBResult
+        {
+            validFor = DateTime.Now,
+            country = "EMU",
+            currency = "euro",
+            amount = 1,
+            currencyCode = "EUR",
+            rate = (decimal)24.952
+        };
+        jpy_rate = new ExchangeRateCNBResult
+        {
+            validFor = DateTime.Now,
+            country = "Japan",
+            currency = "yen",
+            amount = 100,
+            currencyCode = "JPY",
+            rate = (decimal)10.1
+        };
+
+        _mockApiProvider = new Mock<CZKExchangeRateApiProvider> { CallBase = true };
+        _mockApiProvider.Protected().Setup<Task<ExchangeRateCNBApiResponse>>("PerformApiRequest").ReturnsAsync(
+            new ExchangeRateCNBApiResponse
+            {
+                rates = new[] { eur_rate, jpy_rate }
+            }
+        );
+    }
+
+    [Fact]
+    public async void WhenFetchesTheDataReturnsAResultsDictionary()
+    {
+        var exchangeRateProvider = _mockApiProvider.Object;
+
+        var result = await exchangeRateProvider.FetchRates();
+
+        Assert.Equal(2, result.ExchangeRates.Count);
+        Assert.Equal(eur_rate.rate, result.GetRate(eur_rate.currencyCode, "CZK"));
+        Assert.Equal(jpy_rate.rate/100, result.GetRate(jpy_rate.currencyCode, "CZK"));
+    }
+
+}

--- a/jobs/Backend/ExchangeRateTest/ExchangeRateProviderTest.cs
+++ b/jobs/Backend/ExchangeRateTest/ExchangeRateProviderTest.cs
@@ -1,0 +1,84 @@
+using ExchangeRateUpdater;
+using Moq;
+using Moq.Protected;
+
+namespace ExchangeRateTest;
+
+public class ExchangeRateProviderTest
+{
+    private readonly Mock<CZKExchangeRateApiProvider> _mockApiProvider;
+    private readonly Mock<ExchangeRateProvider> _mockExchangeProvider;
+
+    public ExchangeRateProviderTest()
+    {
+        var usd_dictionary = new Dictionary<string, decimal>
+        {
+            { "CZK", (decimal)23.341 },
+            { "EUR", (decimal)0.93 }
+        };
+        var eur_dictionary = new Dictionary<string, decimal>
+        {
+            { "CZK", (decimal)24.945 }
+        };
+        var exchangeDictionary = new Dictionary<string, Dictionary<string, decimal>>
+        {
+            { "USD", usd_dictionary },
+            { "EUR", eur_dictionary }
+        };
+
+        _mockApiProvider = new Mock<CZKExchangeRateApiProvider>();
+        _mockApiProvider.Setup(m => m.FetchRates()).ReturnsAsync(
+            new ExchangeRatesDictionary(exchangeDictionary)
+        );
+        
+        _mockExchangeProvider = new Mock<ExchangeRateProvider>() { CallBase = true };
+        _mockExchangeProvider.Protected().Setup<CZKExchangeRateApiProvider>("CreateApiProvider").Returns(
+            _mockApiProvider.Object
+        );
+    }
+
+    [Fact]
+    public void WhenAsksForAnExistingCurrency()
+    {
+        var exchangeRateProvider = _mockExchangeProvider.Object;
+        var currencies = new[]
+        {
+            new Currency("USD")
+        };
+
+        var result = exchangeRateProvider.GetExchangeRates(currencies);
+
+        Assert.Single(result);
+        Assert.Equal((decimal)23.341, result.First().Value);
+    }
+
+    [Fact]
+    public void WhenAsksForANonExistingCurrency()
+    {
+        var exchangeRateProvider = _mockExchangeProvider.Object;
+        var currencies = new[]
+        {
+            new Currency("XYZ")
+        };
+
+        var result = exchangeRateProvider.GetExchangeRates(currencies);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void WhenAsksForMultipleCurrencies()
+    {
+        var exchangeRateProvider = _mockExchangeProvider.Object;
+        var currencies = new[]
+        {
+            new Currency("EUR"),
+            new Currency("USD"),
+            new Currency("JPY")
+        };
+
+        var result = exchangeRateProvider.GetExchangeRates(currencies);
+
+        Assert.Equal(2, result.Count());
+    }
+}

--- a/jobs/Backend/ExchangeRateTest/ExchangeRateTest.csproj
+++ b/jobs/Backend/ExchangeRateTest/ExchangeRateTest.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="..\Task\ExchangeRateUpdater.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/jobs/Backend/Task/ExchangeRateApiProviders/BaseExchangeRateApiProvider.cs
+++ b/jobs/Backend/Task/ExchangeRateApiProviders/BaseExchangeRateApiProvider.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+
+namespace ExchangeRateUpdater
+{
+    public class ExchangeRatesDictionary
+    {
+        public ExchangeRatesDictionary(Dictionary<string, Dictionary<string, decimal>>? exchangeRates)
+        {
+            ExchangeRates = exchangeRates ?? new Dictionary<string, Dictionary<string, decimal>>();
+        }
+
+        public Dictionary<string, Dictionary<string, decimal>> ExchangeRates { get; }
+
+        public decimal? GetRate(string sourceCurrency, string targetCurrency)
+        {
+            if (ExchangeRates.TryGetValue(sourceCurrency, out var sourceRates))
+            {
+                if (sourceRates.TryGetValue(targetCurrency, out var rate))
+                {
+                    return rate;
+                }
+            }
+
+            return null;
+        }
+    }
+
+    public abstract class BaseExchangeRateApiProvider<T>
+    {
+        public virtual async Task<ExchangeRatesDictionary> FetchRates()
+        {
+            T response = await PerformApiRequest();
+            
+            return TransformToDictionary(response);
+        }
+
+        public abstract string ApiEndpoint { get; }
+
+        private static readonly HttpClient client = new HttpClient();
+
+        protected virtual async Task<T> PerformApiRequest()
+        {
+            var response = await client.GetAsync(ApiEndpoint);
+
+            response.EnsureSuccessStatusCode();
+
+            var responseBody = await response.Content.ReadFromJsonAsync<T>();
+
+            return responseBody;
+        }
+
+        protected abstract ExchangeRatesDictionary TransformToDictionary(T response);
+    }
+}

--- a/jobs/Backend/Task/ExchangeRateApiProviders/CZKExchangeRateApiProvider.cs
+++ b/jobs/Backend/Task/ExchangeRateApiProviders/CZKExchangeRateApiProvider.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+
+
+namespace ExchangeRateUpdater
+{
+    public class ExchangeRateCNBResult
+    {
+        public DateTime validFor { get; set; }
+        public string country { get; set; }
+        public string currency { get; set; }
+        public int amount { get; set; }
+        public string currencyCode { get; set; }
+        public decimal rate { get; set; }
+    }
+
+    public class ExchangeRateCNBApiResponse
+    {
+        public ExchangeRateCNBResult[] rates { get; set; }
+    }
+
+    public class CZKExchangeRateApiProvider : BaseExchangeRateApiProvider<ExchangeRateCNBApiResponse>
+    {
+        public override string ApiEndpoint => "https://api.cnb.cz/cnbapi/exrates/daily?lang=EN";
+
+        protected override ExchangeRatesDictionary TransformToDictionary(ExchangeRateCNBApiResponse response)
+        {
+            var exchangeRates = new Dictionary<string, Dictionary<string, decimal>>();
+
+            foreach (var rate in response.rates)
+            {
+                if (rate.amount == 0)
+                {
+                    continue;
+                }
+
+                exchangeRates[rate.currencyCode] = new Dictionary<string, decimal>
+                {
+                    { "CZK", rate.rate/rate.amount }
+                };
+            }
+
+            return new ExchangeRatesDictionary(exchangeRates);
+        }
+    }
+}

--- a/jobs/Backend/Task/ExchangeRateProvider.cs
+++ b/jobs/Backend/Task/ExchangeRateProvider.cs
@@ -1,10 +1,12 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 
 namespace ExchangeRateUpdater
 {
     public class ExchangeRateProvider
     {
+        // I'm supposing that, if it's just passing currencies, it will always be checked against CZK. Adding it here as default just
+        // in case in the future is needed to support other currency pairs.
+        private static Currency DEFAULT_CURRENCY = new Currency("CZK");
         /// <summary>
         /// Should return exchange rates among the specified currencies that are defined by the source. But only those defined
         /// by the source, do not return calculated exchange rates. E.g. if the source contains "CZK/USD" but not "USD/CZK",
@@ -13,7 +15,30 @@ namespace ExchangeRateUpdater
         /// </summary>
         public IEnumerable<ExchangeRate> GetExchangeRates(IEnumerable<Currency> currencies)
         {
-            return Enumerable.Empty<ExchangeRate>();
+            // .Result will make the call synchronous. I didn't want to modify the provided methods signature and for
+            // this case we will need to get the information synchronously anyways.
+            ExchangeRatesDictionary exchangeList = CreateApiProvider().FetchRates().Result;
+
+            List<ExchangeRate> exchangeRates = new List<ExchangeRate>();
+
+            foreach (var initialCurrency in currencies)
+            {
+                Currency targetCurrency = DEFAULT_CURRENCY;
+
+                var value = exchangeList.GetRate(initialCurrency.Code, targetCurrency.Code);
+
+                if (value != null)
+                {
+                    exchangeRates.Add(new ExchangeRate(initialCurrency, targetCurrency, value.Value));
+                }
+            }
+
+            return exchangeRates;
+        }
+
+        protected virtual CZKExchangeRateApiProvider CreateApiProvider()
+        {
+            return new CZKExchangeRateApiProvider();
         }
     }
 }


### PR DESCRIPTION
This commit contains the implementation for the .Net challenge that we can find in this repository.

I tried to make the solution as straight forward as possible, having a `CZKExchangeRageApiProvider` that will take care of fetching the data of CZK currency. It inherits from `BaseExchangeRateApiProvider` so, if in the future we want to add other APIs, we all follow the same pattern. Additionally, this could help for future implementation of a cache or similar strategies in case it's a highly requested provider.